### PR TITLE
Fix database config version control hassle

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ default: &default
 development:
   <<: *default
   database: owdashboard_dev
-  username: Chester
+  username: <%= ENV['DATABASE_USER'] || ENV['USER'] || 'postgres' %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -15,7 +15,7 @@ development:
 test:
   <<: *default
   database: owdashboard_test
-  username: postgres
+  username: <%= ENV['DATABASE_USER'] || ENV['USER'] || 'postgres' %>
 
 production:
   <<: *default


### PR DESCRIPTION
# Purpose
This uses environment variables as fallback options for the database username in `config/database.yml`. 

It tries `DATABASE_USERNAME` first, before trying `USER` (this is almost always going to work on macOS' Postgres for development) and then simply the string `'postgres'` (which will allow for Travis' rspec tests to use the test database)

No more notices of 'please do not check in `database.yml`' will exist anymore.